### PR TITLE
fix(bootstrap): update VAULT environment variable for main cluster

### DIFF
--- a/.taskfiles/bootstrap/Taskfile.yaml
+++ b/.taskfiles/bootstrap/Taskfile.yaml
@@ -20,7 +20,7 @@ tasks:
       TEMPLATES:
         sh: ls {{.CLUSTER_DIR}}/bootstrap/apps/*.j2
     env:
-      VAULT: '{{if eq .CLUSTER "main"}}kubernetes{{else}}{{.CLUSTER}}{{end}}'
+      VAULT: '{{if eq .CLUSTER "main"}}ocp-neptune{{else}}{{.CLUSTER}}{{end}}'
       FLUX_GITHUB_PUBLIC_KEYS:
         sh: curl -fsSL https://api.github.com/meta | jq --raw-output '"github.com "+.ssh_keys[]'
     requires:


### PR DESCRIPTION
The VAULT environment variable has been updated to use 'ocp-neptune' instead of 'kubernetes' when the CLUSTER is 'main'. This change ensures the correct vault is used for the main cluster configuration.