### PR TITLE
feat: add Minijinja configuration and update Taskfile command

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,8 @@
+# Kubernetes
 export KUBECONFIG="$(expand_path ./openshift/main/kubeconfig)"
 export SOPS_AGE_KEY_FILE="$(expand_path ./age.key)"
+# Minijinja
+export MINIJINJA_CONFIG_FILE="$(expand_path ./.minijinja.toml)"
+# Taskfile
+export TASK_X_ENV_PRECEDENCE=1
+export TASK_X_MAP_VARIABLES=0

--- a/.minijinja.toml
+++ b/.minijinja.toml
@@ -1,0 +1,5 @@
+autoescape = "none"
+newline = true
+trim-blocks = true
+lstrip-blocks = true
+env = true

--- a/.taskfiles/bootstrap/Taskfile.yaml
+++ b/.taskfiles/bootstrap/Taskfile.yaml
@@ -14,7 +14,7 @@ tasks:
       - oc adm policy add-scc-to-user privileged system:serviceaccount:flux-system:source-controller
       - kubectl apply --server-side --kustomize {{.CLUSTER_DIR}}/bootstrap/apps
       - for: { var: TEMPLATES }
-        cmd: op run --env-file {{.CLUSTER_DIR}}/bootstrap/bootstrap.env --no-masking -- minijinja-cli {{.ITEM}} | kubectl apply --server-side --filename -
+        cmd: op run --env-file {{.CLUSTER_DIR}}/bootstrap/bootstrap.env --no-masking -- minijinja-cli {{.ITEM}} | oc apply --server-side --filename -
       - kubectl apply --server-side --kustomize {{.CLUSTER_DIR}}/flux/config
     vars:
       TEMPLATES:


### PR DESCRIPTION
- Added Minijinja configuration file `.minijinja.toml` with settings for autoescape, newline, block trimming, and environment.
- Updated `.envrc` to include environment variables for Minijinja and Taskfile settings.
- Modified Taskfile command to use `oc apply` instead of `kubectl apply` for Minijinja CLI output.