### PR TITLE
feat(external-secrets): add kustomization and helmrelease for onepassword-connect

### DIFF
--- a/openshift/main/apps/external-secrets/kustomization.yaml
+++ b/openshift/main/apps/external-secrets/kustomization.yaml
@@ -2,7 +2,8 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: flux-system
 resources:
-  - ./bjw-s.yaml
-  - ./external-secrets.yaml
+  # Pre Flux-Kustomizations
+  - ./namespace.yaml
+  # Flux-Kustomizations
+  - ./onepassword-connect/ks.yaml

--- a/openshift/main/apps/external-secrets/namespace.yaml
+++ b/openshift/main/apps/external-secrets/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-secrets
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/openshift/main/apps/external-secrets/onepassword-connect/app/helmrelease.yaml
+++ b/openshift/main/apps/external-secrets/onepassword-connect/app/helmrelease.yaml
@@ -1,0 +1,125 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: onepassword-connect
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 3.5.1
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    controllers:
+      onepassword-connect:
+        strategy: RollingUpdate
+        replicas: 2
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          api:
+            image:
+              repository: docker.io/1password/connect-api
+              tag: 1.7.3@sha256:0601c7614e102eada268dbda6ba4b5886ce77713be2c332ec6a2fd0f028484ba
+            env:
+              XDG_DATA_HOME: &configDir /config
+              OP_HTTP_PORT: &apiPort 80
+              OP_BUS_PORT: 11220
+              OP_BUS_PEERS: localhost:11221
+              OP_SESSION:
+                valueFrom:
+                  secretKeyRef:
+                    name: onepassword-connect-secret
+                    key: 1password-credentials.json
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /heartbeat
+                    port: *apiPort
+                  initialDelaySeconds: 15
+                  periodSeconds: 30
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: *apiPort
+                  initialDelaySeconds: 15
+            securityContext: &securityContext
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources: &resources
+              requests:
+                cpu: 10m
+              limits:
+                memory: 256M
+          sync:
+            image:
+              repository: docker.io/1password/connect-sync
+              tag: 1.7.3@sha256:2f17621c7eb27bbcb1f86bbc5e5a5198bf54ac3b9c2ffac38064d03c932b07d5
+            env:
+              XDG_DATA_HOME: *configDir
+              OP_HTTP_PORT: &syncPort 8081
+              OP_BUS_PORT: 11221
+              OP_BUS_PEERS: localhost:11220
+              OP_SESSION:
+                valueFrom:
+                  secretKeyRef:
+                    name: onepassword-connect-secret
+                    key: 1password-credentials.json
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /heartbeat
+                    port: *syncPort
+                  initialDelaySeconds: 15
+                  periodSeconds: 30
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: *syncPort
+                  initialDelaySeconds: 15
+            securityContext: *securityContext
+            resources: *resources
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: { type: RuntimeDefault }
+    service:
+      app:
+        controller: onepassword-connect
+        ports:
+          http:
+            port: *apiPort
+    persistence:
+      config:
+        type: emptyDir
+        globalMounts:
+          - path: *configDir

--- a/openshift/main/apps/external-secrets/onepassword-connect/app/kustomization.yaml
+++ b/openshift/main/apps/external-secrets/onepassword-connect/app/kustomization.yaml
@@ -2,7 +2,5 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: flux-system
 resources:
-  - ./bjw-s.yaml
-  - ./external-secrets.yaml
+  - ./helmrelease.yaml

--- a/openshift/main/apps/external-secrets/onepassword-connect/ks.yaml
+++ b/openshift/main/apps/external-secrets/onepassword-connect/ks.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app onepassword-connect
+  namespace: flux-system
+spec:
+  targetNamespace: external-secrets
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./openshift/main/apps/external-secrets/onepassword-connect/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: ocp-neptune
+  wait: false
+  interval: 30m
+  timeout: 5m

--- a/openshift/main/flux/repos/helm/bjw-s.yaml
+++ b/openshift/main/flux/repos/helm/bjw-s.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/helmrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: bjw-s
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 5m
+  url: oci://ghcr.io/bjw-s/helm


### PR DESCRIPTION
- Introduced kustomization.yaml for external-secrets to manage resources.
- Added namespace.yaml to define the external-secrets namespace with specific labels.
- Created helmrelease.yaml for deploying onepassword-connect using HelmRelease.
- Configured kustomization.yaml in onepassword-connect/app to include helmrelease.yaml.
- Added ks.yaml for kustomization in onepassword-connect with GitRepository source reference.
- Introduced bjw-s.yaml in flux/repos/helm to define HelmRepository for bjw-s.
- Updated kustomization.yaml in flux/repos/helm to include bjw-s.yaml.