### PR TITLE
fix(cluster.yaml): update Git URL format

### DIFF
--- a/openshift/main/flux/config/cluster.yaml
+++ b/openshift/main/flux/config/cluster.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 30m
-  url: ssh://git@github.com:ario-automation/ocp-neptune.git
+  url: ssh://git@github.com/ario-automation/ocp-neptune
   ref:
     branch: main
   secretRef:


### PR DESCRIPTION
The Git URL in the cluster configuration has been updated to remove the colon after 'github.com', ensuring proper URL formatting for SSH access.