### PR TITLE
fix(onepassword-connect): update OP_HTTP_PORT to 8080

### DIFF
--- a/openshift/main/apps/external-secrets/onepassword-connect/app/helmrelease.yaml
+++ b/openshift/main/apps/external-secrets/onepassword-connect/app/helmrelease.yaml
@@ -36,7 +36,7 @@ spec:
               tag: 1.7.3@sha256:0601c7614e102eada268dbda6ba4b5886ce77713be2c332ec6a2fd0f028484ba
             env:
               XDG_DATA_HOME: &configDir /config
-              OP_HTTP_PORT: &apiPort 80
+              OP_HTTP_PORT: &apiPort 8080
               OP_BUS_PORT: 11220
               OP_BUS_PEERS: localhost:11221
               OP_SESSION:


### PR DESCRIPTION
Changed the OP_HTTP_PORT environment variable from 80 to 8080 in the helmrelease.yaml file to due to the pod not having permissions to bind to port 80.