### PR TITLE
feat(external-secrets): add HelmRelease and Kustomization configurations

### DIFF
--- a/openshift/main/apps/external-secrets/external-secrets/app/helmrelease.yaml
+++ b/openshift/main/apps/external-secrets/external-secrets/app/helmrelease.yaml
@@ -1,0 +1,48 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: external-secrets
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: external-secrets
+      version: 0.11.0
+      sourceRef:
+        kind: HelmRepository
+        name: external-secrets
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  dependsOn:
+    - name: onepassword-connect
+      namespace: external-secrets
+  values:
+    installCRDs: true
+    replicaCount: 2
+    leaderElect: true
+    image:
+      repository: ghcr.io/external-secrets/external-secrets
+    webhook:
+      image:
+        repository: ghcr.io/external-secrets/external-secrets
+      serviceMonitor:
+        enabled: true
+        interval: 1m
+    certController:
+      image:
+        repository: ghcr.io/external-secrets/external-secrets
+      serviceMonitor:
+        enabled: true
+        interval: 1m
+    serviceMonitor:
+      enabled: true
+      interval: 1m

--- a/openshift/main/apps/external-secrets/external-secrets/app/kustomization.yaml
+++ b/openshift/main/apps/external-secrets/external-secrets/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/openshift/main/apps/external-secrets/external-secrets/ks.yaml
+++ b/openshift/main/apps/external-secrets/external-secrets/ks.yaml
@@ -1,0 +1,42 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app external-secrets
+  namespace: flux-system
+spec:
+  targetNamespace: external-secrets
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./openshift/main/apps/external-secrets/external-secrets/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: ocp-neptune
+  wait: true
+  interval: 30m
+  timeout: 5m
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app external-secrets-stores
+  namespace: flux-system
+spec:
+  targetNamespace: external-secrets
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: external-secrets
+  path: ./openshift/main/apps/external-secrets/external-secrets/stores
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: ocp-neptune
+  wait: true
+  interval: 30m
+  timeout: 5m

--- a/openshift/main/apps/external-secrets/external-secrets/stores/clustersecretstore.yaml
+++ b/openshift/main/apps/external-secrets/external-secrets/stores/clustersecretstore.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/clustersecretstore_v1beta1.json
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: onepassword-connect
+spec:
+  provider:
+    onepassword:
+      connectHost: http://onepassword-connect.external-secrets.svc.cluster.local:8080
+      vaults:
+        ocp-neptune: 1
+      auth:
+        secretRef:
+          connectTokenSecretRef:
+            name: onepassword-connect-secret
+            key: token
+            namespace: external-secrets

--- a/openshift/main/apps/external-secrets/external-secrets/stores/kustomization.yaml
+++ b/openshift/main/apps/external-secrets/external-secrets/stores/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./clustersecretstore.yaml


### PR DESCRIPTION
- Introduced `helmrelease.yaml` for managing the external-secrets Helm chart with FluxCD.
- Added `kustomization.yaml` in the app directory to include the HelmRelease resource.
- Created `ks.yaml` for Kustomization setup, defining target namespace and dependencies.
- Implemented `clustersecretstore.yaml` for configuring ClusterSecretStore with OnePassword provider.
- Added `kustomization.yaml` in the stores directory to manage ClusterSecretStore resources.