### PR TITLE
fix(certificates): correct wildcard DNS entry for Neptune apps

### DIFF
--- a/openshift/main/apps/cert-manager/certificates/app/certificates.yaml
+++ b/openshift/main/apps/cert-manager/certificates/app/certificates.yaml
@@ -13,4 +13,4 @@ spec:
   dnsNames:
     - "${SECRET_DOMAIN}"
     - "*.${SECRET_DOMAIN}"
-    - ".apps.neptune.${SECRET_DOMAIN}"
+    - "*.apps.neptune.${SECRET_DOMAIN}"


### PR DESCRIPTION
Updated the DNS entry in the certificates configuration to use a wildcard for Neptune apps, ensuring proper certificate coverage for all subdomains.