### PR TITLE
feat(openshift): add Taskfile for syncing ExternalSecrets

### DIFF
--- a/.taskfiles/openshift/Taskfile.yaml
+++ b/.taskfiles/openshift/Taskfile.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://taskfile.dev/schema.json
+version: "3"
+
+tasks:
+  sync-secrets:
+    desc: Sync all ExternalSecrets [CLUSTER=main]
+    cmds:
+      - for: { var: SECRETS, split: "\n" }
+        cmd: oc --namespace {{splitList "," .ITEM | first}} annotate externalsecret {{splitList "," .ITEM | last}} force-sync="{{now | unixEpoch}}" --overwrite
+    vars:
+      SECRETS:
+        sh: oc get externalsecret --all-namespaces --no-headers --output=jsonpath='{range .items[*]}{.metadata.namespace},{.metadata.name}{"\n"}{end}'
+    requires:
+      vars: [CLUSTER]
+    preconditions:
+      - which oc

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -15,6 +15,7 @@ env:
 
 includes:
   bootstrap: .taskfiles/bootstrap
+  openshift: .taskfiles/openshift
 
 tasks:
   default:

--- a/openshift/main/apps/cert-manager/certificates/app/certificates.yaml
+++ b/openshift/main/apps/cert-manager/certificates/app/certificates.yaml
@@ -4,6 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: "${SECRET_DOMAIN//./-}-staging"
+  namespace: openshift-ingress
 spec:
   secretName: "${SECRET_DOMAIN//./-}-tls-staging"
   issuerRef:


### PR DESCRIPTION
- Introduced a new Taskfile.yaml under .taskfiles/openshift to handle syncing of ExternalSecrets.
- Added a task `sync-secrets` to annotate ExternalSecrets for force-syncing.
- Included the openshift Taskfile in the main Taskfile.yaml.
- Updated the certificates.yaml to specify the namespace for certificates as `openshift-ingress`.