### PR TITLE
chore(certificates): remove namespace from certificate metadata

### DIFF
--- a/openshift/main/apps/cert-manager/certificates/app/certificates.yaml
+++ b/openshift/main/apps/cert-manager/certificates/app/certificates.yaml
@@ -4,7 +4,6 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: "${SECRET_DOMAIN//./-}-staging"
-  namespace: openshift-ingress
 spec:
   secretName: "${SECRET_DOMAIN//./-}-tls-staging"
   issuerRef:


### PR DESCRIPTION
The namespace field has been removed from the certificate metadata in the certificates.yaml file. This change ensures that the namespace is not explicitly set for the certificate resource.