### PR TITLE
feat(cert-manager): add production ClusterIssuer and Certificate

### DIFF
--- a/openshift/main/apps/cert-manager/cert-manager/issuers/issuers.yaml
+++ b/openshift/main/apps/cert-manager/cert-manager/issuers/issuers.yaml
@@ -3,6 +3,27 @@
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
+  name: letsencrypt-production
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: "${SECRET_CLOUDFLARE_EMAIL}"
+    privateKeySecretRef:
+      name: letsencrypt-production
+    solvers:
+      - dns01:
+          cloudflare:
+            email: "${SECRET_CLOUDFLARE_EMAIL}"
+            apiKeySecretRef:
+              name: cloudflare-secret
+              key: CLOUDFLARE_API_KEY
+        selector:
+          dnsZones: ["${SECRET_DOMAIN}"]
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cert-manager.io/clusterissuer_v1.json
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
   name: letsencrypt-staging
 spec:
   acme:

--- a/openshift/main/apps/cert-manager/certificates/app/certificates.yaml
+++ b/openshift/main/apps/cert-manager/certificates/app/certificates.yaml
@@ -3,6 +3,23 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
+  name: "${SECRET_DOMAIN//./-}"
+  namespace: openshift-ingress
+spec:
+  secretName: "${SECRET_DOMAIN//./-}-tls"
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  commonName: "${SECRET_DOMAIN}"
+  dnsNames:
+    - "${SECRET_DOMAIN}"
+    - "*.${SECRET_DOMAIN}"
+    - "*.apps.neptune.${SECRET_DOMAIN}"
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cert-manager.io/certificate_v1.json
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
   name: "${SECRET_DOMAIN//./-}-staging"
 spec:
   secretName: "${SECRET_DOMAIN//./-}-tls-staging"


### PR DESCRIPTION
- Added a new ClusterIssuer named `letsencrypt-production` in `issuers.yaml` for production environment using Let's Encrypt.
- Configured ACME server, email, and Cloudflare DNS01 solver for production issuer.
- Introduced a new Certificate in `certificates.yaml` for production with a secret name based on the domain.
- Updated the Certificate to use the `letsencrypt-production` ClusterIssuer.
- Included DNS names for the domain and subdomains in the production Certificate configuration.