### PR TITLE
fix(certificates): add namespace to certificate and remove targetNamespace

### DIFF
--- a/openshift/main/apps/cert-manager/certificates/app/certificates.yaml
+++ b/openshift/main/apps/cert-manager/certificates/app/certificates.yaml
@@ -21,6 +21,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: "${SECRET_DOMAIN//./-}-staging"
+  namespace: openshift-ingress
 spec:
   secretName: "${SECRET_DOMAIN//./-}-tls-staging"
   issuerRef:

--- a/openshift/main/apps/cert-manager/certificates/ks.yaml
+++ b/openshift/main/apps/cert-manager/certificates/ks.yaml
@@ -6,7 +6,6 @@ metadata:
   name: &app certificates
   namespace: flux-system
 spec:
-  targetNamespace: cert-manager
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app


### PR DESCRIPTION
- Added `namespace: openshift-ingress` to `certificates.yaml` to specify the namespace for the certificate.
- Removed `targetNamespace: cert-manager` from `ks.yaml` to align with the updated configuration.