### PR TITLE
fix(hashicorp-vault): update secret reference from secret > secretName to match helm values

### DIFF
--- a/openshift/main/apps/infra/vault/app/helmrelease.yaml
+++ b/openshift/main/apps/infra/vault/app/helmrelease.yaml
@@ -42,13 +42,13 @@ spec:
         accessMode: ReadWriteOnce
       extraSecretEnvironmentVars:
         - envName: AWS_ACCESS_KEY_ID
-          secret: vault-secret
+          secretName: vault-secret
           secretKey: AWS_ACCESS_KEY_ID
         - envName: AWS_SECRET_ACCESS_KEY
-          secret: vault-secret
+          secretName: vault-secret
           secretKey: AWS_SECRET_ACCESS_KEY
         - envName: VAULT_AWSKMS_SEAL_KEY_ID
-          secret: vault-secret
+          secretName: vault-secret
           secretKey: VAULT_AWSKMS_SEAL_KEY_ID
       extraEnvironmentVars:
         TZ: ${TIMEZONE}


### PR DESCRIPTION
`create Pod vault-0 in StatefulSet vault failed error: Pod "vault-0" is invalid: [spec.containers[0].env[12].valueFrom.secretKeyRef.name: Invalid value: "": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')`
