### PR TITLE
refactor(vault): remove duplicate awskms seal configuration

### DIFF
--- a/openshift/main/apps/infra/vault/app/helmrelease.yaml
+++ b/openshift/main/apps/infra/vault/app/helmrelease.yaml
@@ -68,9 +68,6 @@ spec:
           seal "awskms" {
             region = "us-east-1"
           }
-          seal "awskms" {
-            region = "us-east-1"
-          }
           # HTTPS listener
           listener "tcp" {
             address = "[::]:8200"


### PR DESCRIPTION
The duplicate awskms seal configuration in the helmrelease.yaml file has been removed to ensure clarity and prevent potential configuration conflicts.