### PR TITLE
feat(vault): add storageClass to PVC configuration

### DIFF
--- a/openshift/main/apps/infra/vault/app/helmrelease.yaml
+++ b/openshift/main/apps/infra/vault/app/helmrelease.yaml
@@ -40,6 +40,7 @@ spec:
         size: 20Gi
         mountPath: "/vault/data"
         accessMode: ReadWriteOnce
+        storageClass: odf-storageclass
       extraSecretEnvironmentVars:
         - envName: AWS_ACCESS_KEY_ID
           secretName: vault-secret


### PR DESCRIPTION
Added `storageClass: odf-storageclass` to the PersistentVolumeClaim configuration in the Vault HelmRelease to specify the storage class for the volume. This change ensures that the correct storage class is used for provisioning the volume.