### PR TITLE
chore(kustomization): comment out vault resource in kustomization.yaml

### DIFF
--- a/openshift/main/apps/infra/kustomization.yaml
+++ b/openshift/main/apps/infra/kustomization.yaml
@@ -4,4 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./namespace.yaml
-  - ./vault/ks.yaml
+  # - ./vault/ks.yaml


### PR DESCRIPTION
The vault resource in the kustomization.yaml file has been commented out.