### PR TITLE
feat(vault): add file storage configuration

### DIFF
--- a/openshift/main/apps/infra/vault/app/helmrelease.yaml
+++ b/openshift/main/apps/infra/vault/app/helmrelease.yaml
@@ -69,6 +69,9 @@ spec:
           seal "awskms" {
             region = "us-east-1"
           }
+          storage "file" {
+            path = "/vault/data"
+          }
           # HTTPS listener
           listener "tcp" {
             address = "[::]:8200"


### PR DESCRIPTION
Added file storage configuration to the Vault Helm release. This change specifies the storage path as "/vault/data" to enable file-based storage for Vault data.