### PR TITLE
chore: comment out helmrelease.yaml in kustomization.yaml

### DIFF
--- a/openshift/main/apps/infra/vault/app/kustomization.yaml
+++ b/openshift/main/apps/infra/vault/app/kustomization.yaml
@@ -4,6 +4,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./externalsecret.yaml
-  - ./helmrelease.yaml
+  # - ./helmrelease.yaml
   - ./route.yaml
   - ../../../../templates/volsync


### PR DESCRIPTION
This change comments out the helmrelease.yaml resource in the kustomization.yaml file for the Vault app. I need to remove the older PVC so that I can create one backed by volsync.