### PR TITLE
feat(volsync): update storage class names

### DIFF
--- a/openshift/main/templates/volsync/r2.yaml
+++ b/openshift/main/templates/volsync/r2.yaml
@@ -36,9 +36,9 @@ spec:
     repository: "${APP}-volsync-r2-secret"
     volumeSnapshotClassName: "${VOLSYNC_SNAPSHOTCLASS:-ocs-storagecluster-rbdplugin-snapclass}"
     cacheCapacity: "${VOLSYNC_CACHE_CAPACITY:-2Gi}"
-    cacheStorageClassName: "${VOLSYNC_CACHE_SNAPSHOTCLASS:-odf-storageclass}"
+    cacheStorageClassName: "${VOLSYNC_CACHE_SNAPSHOTCLASS:-ocs-storagecluster-ceph-rbd}"
     cacheAccessModes: ["${VOLSYNC_CACHE_ACCESSMODES:-ReadWriteOnce}"]
-    storageClassName: "${VOLSYNC_STORAGECLASS:-odf-storageclass}"
+    storageClassName: "${VOLSYNC_STORAGECLASS:-ocs-storagecluster-ceph-rbd}"
     accessModes: ["${VOLSYNC_ACCESSMODES:-ReadWriteOnce}"]
     retain:
       daily: 7
@@ -55,10 +55,10 @@ spec:
     repository: "${APP}-volsync-secret"
     copyMethod: Snapshot # must be Snapshot
     volumeSnapshotClassName: "${VOLSYNC_SNAPSHOTCLASS:-ocs-storagecluster-rbdplugin-snapclass}"
-    cacheStorageClassName: "${VOLSYNC_CACHE_SNAPSHOTCLASS:-odf-storageclass}"
+    cacheStorageClassName: "${VOLSYNC_CACHE_SNAPSHOTCLASS:-ocs-storagecluster-ceph-rbd}"
     cacheAccessModes: ["${VOLSYNC_CACHE_ACCESSMODES:-ReadWriteOnce}"]
     cacheCapacity: "${VOLSYNC_CACHE_CAPACITY:-2Gi}"
-    storageClassName: "${VOLSYNC_STORAGECLASS:-odf-storageclass}"
+    storageClassName: "${VOLSYNC_STORAGECLASS:-ocs-storagecluster-ceph-rbd}"
     accessModes: ["${VOLSYNC_ACCESSMODES:-ReadWriteOnce}"]
     capacity: "${VOLSYNC_CAPACITY:-5Gi}"
     enableFileDeletion: true


### PR DESCRIPTION
Updated the default storage class names for cache and main storage from 'odf-storageclass' to 'ocs-storagecluster-ceph-rbd' in the volsync configuration. This change ensures compatibility with the ocs-storagecluster-ceph-rbd setup.