### PR TITLE
feat(database): add cloudnative-pg configuration

### DIFF
--- a/openshift/main/apps/database/cloudnative-pg/app/externalsecret.yaml
+++ b/openshift/main/apps/database/cloudnative-pg/app/externalsecret.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: cloudnative-pg
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: cloudnative-pg-secret
+    template:
+      engineVersion: v2
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+  data:
+    - secretKey: username
+      remoteRef:
+        key: cloudnative-pg
+        property: POSTGRES_SUPER_USER
+    - secretKey: password
+      remoteRef:
+        key: cloudnative-pg
+        property: POSTGRES_SUPER_PASS
+    - secretKey: aws-access-key-id
+      remoteRef:
+        key: cloudnative-pg
+        property: CLOUDFLARE_ACCESS_KEY_ID
+    - secretKey: aws-secret-access-key
+      remoteRef:
+        key: cloudnative-pg
+        property: CLOUDFLARE_SECRET_ACCESS_KEY

--- a/openshift/main/apps/database/cloudnative-pg/app/kustomization.yaml
+++ b/openshift/main/apps/database/cloudnative-pg/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./subscription.yaml

--- a/openshift/main/apps/database/cloudnative-pg/app/subscription.yaml
+++ b/openshift/main/apps/database/cloudnative-pg/app/subscription.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: cloudnative-pg-operator
+spec:
+  targetNamespaces:
+    - database
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: cloudnative-pg-operator
+spec:
+  channel: stable-v1
+  installPlanApproval: Automatic
+  name: cloudnative-pg
+  source: certified-operators
+  sourceNamespace: openshift-marketplace

--- a/openshift/main/apps/database/cloudnative-pg/ks.yaml
+++ b/openshift/main/apps/database/cloudnative-pg/ks.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app cloudnative-pg
+  namespace: flux-system
+spec:
+  targetNamespace: database
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: external-secrets-stores
+  path: ./openshift/main/apps/database/cloudnative-pg/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: ocp-neptune
+  wait: true
+  interval: 30m
+  timeout: 5m

--- a/openshift/main/apps/database/kustomization.yaml
+++ b/openshift/main/apps/database/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  # Pre Flux-Kustomizations
+  - ./namespace.yaml
+  # Flux-Kustomizations
+  - ./cloudnative-pg/ks.yaml

--- a/openshift/main/apps/database/namespace.yaml
+++ b/openshift/main/apps/database/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: database
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    volsync.backube/privileged-movers: "true"


### PR DESCRIPTION
- Introduced `externalsecret.yaml` for managing external secrets with cloudnative-pg.
- Added `kustomization.yaml` to include resources for cloudnative-pg.
- Created `subscription.yaml` for operator group and subscription setup.
- Implemented `ks.yaml` for FluxCD kustomization of cloudnative-pg.
- Updated main `kustomization.yaml` to include namespace and cloudnative-pg configurations.
- Added `namespace.yaml` to define the database namespace with necessary annotations.