### PR TITLE
feat(database): add CloudNative PG cluster configuration

### DIFF
--- a/openshift/main/apps/database/cloudnative-pg/cluster/cluster.yaml
+++ b/openshift/main/apps/database/cloudnative-pg/cluster/cluster.yaml
@@ -1,0 +1,46 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/postgresql.cnpg.io/cluster_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgres
+spec:
+  imageName: ghcr.io/cloudnative-pg/postgresql:16.6@sha256:d7822fa6eba284a6d3d035d51a51de22147bc5e72d87aa93e7dd9fa87455ed5c
+  instances: 3
+  primaryUpdateStrategy: unsupervised
+  storage:
+    size: 60Gi
+    storageClass: ocs-storagecluster-ceph-rbd
+  superuserSecret:
+    name: cloudnative-pg-secret
+  enableSuperuserAccess: true
+  postgresql:
+    parameters:
+      max_connections: "250"
+      shared_buffers: 128MB
+  resources:
+    requests:
+      cpu: 500m
+    limits:
+      hugepages-2Mi: 2Gi # Requires sysctl set on the host
+      memory: 4Gi
+  monitoring:
+    enablePodMonitor: true
+  backup:
+    retentionPolicy: 30d
+    barmanObjectStore:
+      data:
+        compression: bzip2
+      wal:
+        compression: bzip2
+        maxParallel: 8
+      destinationPath: s3://ocp-neptune-cloudnative-pg/
+      endpointURL: https://${SECRET_CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com
+      serverName: postgres
+      s3Credentials:
+        accessKeyId:
+          name: cloudnative-pg-secret
+          key: aws-access-key-id
+        secretAccessKey:
+          name: cloudnative-pg-secret
+          key: aws-secret-access-key

--- a/openshift/main/apps/database/cloudnative-pg/cluster/kustomization.yaml
+++ b/openshift/main/apps/database/cloudnative-pg/cluster/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./cluster.yaml
+  - ./scheduledbackup.yaml

--- a/openshift/main/apps/database/cloudnative-pg/cluster/scheduledbackup.yaml
+++ b/openshift/main/apps/database/cloudnative-pg/cluster/scheduledbackup.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/postgresql.cnpg.io/scheduledbackup_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: postgres
+spec:
+  schedule: "@daily"
+  immediate: true
+  backupOwnerReference: self
+  cluster:
+    name: postgres

--- a/openshift/main/apps/database/cloudnative-pg/ks.yaml
+++ b/openshift/main/apps/database/cloudnative-pg/ks.yaml
@@ -20,3 +20,25 @@ spec:
   wait: true
   interval: 30m
   timeout: 5m
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app cloudnative-pg-cluster
+  namespace: flux-system
+spec:
+  targetNamespace: database
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: cloudnative-pg
+  path: ./openshift/main/apps/database/cloudnative-pg/cluster
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: ocp-neptune
+  wait: true
+  interval: 30m
+  timeout: 5m

--- a/openshift/main/flux/vars/cluster-secrets.secret.sops.yaml
+++ b/openshift/main/flux/vars/cluster-secrets.secret.sops.yaml
@@ -4,6 +4,7 @@ metadata:
     name: cluster-secrets
     namespace: flux-system
 stringData:
+    SECRET_CLOUDFLARE_ACCOUNT_ID: ENC[AES256_GCM,data:62BsmaxAGQylRrV9D90yPIRXLrGr6jlV2egQkcNXOXQ=,iv:G+ViDi0HwypkEcWQ7/7atEx4+Ln9tvEDnwIajC1/OJE=,tag:cxzUBCWU8YII0gcdQL8pzA==,type:str]
     SECRET_CLOUDFLARE_EMAIL: ENC[AES256_GCM,data:E0VmH1PMl7T7nTrlsFo=,iv:ecU/ycxnHKDu5R7vhlONfCnTZjDVSnkH9R9Dx9/fvNw=,tag:tPmBIS4qF7s0znwuqyYLug==,type:str]
     SECRET_CLOUDFLARE_TUNNEL_SECRET: ENC[AES256_GCM,data:Y4JWKzcmoJeJqy+GbHZYqVPzWl+YHy4g/+B8mMHRIa8t5RoYTiXY2ywlFTw95CR0nKGBq5bRSkFyLBPDcDIhWHwz0yUDc2jEmX6S3jZEE1qpHND/5Nl3pvNNFDKiOlVJvbD4kkrn9yY5ZrzdVxHqpHHylMMcmellI944jdqWR5idtj2rWix+UBRMicWkKDs/AL9z88Q6f8+JUVh+xx9Ih9pQWrQWkrBtdnkSDpd1PYuRt48KfI8GOA==,iv:hXe3SMj02n9bp5zNBVvDJAmfHVjoBH8UwMdwv0Xg3Pw=,tag:2q/eRjr011iDbkbsu7h0Zw==,type:str]
     SECRET_DOMAIN: ENC[AES256_GCM,data:9BRnngz6vLH6bEr5,iv:5CgsuSV8oumI8/RTKxr8/NvrE6q3YjEog+KjQrg7LzQ=,tag:fjCh/Q54kiVOx3z87qGyag==,type:str]
@@ -22,8 +23,8 @@ sops:
             Z0IrS2VjdlNkVjRwZGM3dGIzQ1J1UncKPC6jCRyuhmHnqemLn+HaZ1eGtVLnG4R4
             ONcKXvP8BYqbArQdF6pcfkO0vvOEE8K1m5S9guP9kKj7FemFpmdVqA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-12-20T21:45:39Z"
-    mac: ENC[AES256_GCM,data:A5bqMKjjodsJmQ02j/+LLF3lpN34wrJRUpjlXH+8edVb62e5q21Fme3gK2thkP89Vlf/9O2QnZJUiSQEF+uSzvIaVf0+vUtJuBodw7M/qPq/miR0yN3jZ/HQrb7xlXNsKwvs8vwwSeNZCA0p5wTaAQdZR2/dey5hd6n0qeqWbUE=,iv:bkOK/RBY8k4TVC+hrKXHm+kwDKt1tNYU01BcTUsRAK0=,tag:qReDkppgbK+exMby2h5tXA==,type:str]
+    lastmodified: "2024-12-22T03:59:37Z"
+    mac: ENC[AES256_GCM,data:eUjid6pzTJweTYPN9bliz5sMLlrWLnbjGD0ZyPQrTT4R6TQfVDlvF6opbNMG4/42Cp0zyfzkGiYotIbqbiV1S7yeWCYGG36PRFqPE4M1RkoRtvdnklIHwHqoJOchSY+X3ZUW8Bdw6nNLpj1aT3Krqy6/A1urqihrLR/0NmmCdaU=,iv:YWBkT8J/GcQcXXAnP128UYRuy8Hl2yXsVayZnBJaIYE=,tag:W9r2TKcVhHkmY5hcEpFTqQ==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     mac_only_encrypted: true


### PR DESCRIPTION
- Introduced a new cluster.yaml file for CloudNative PG with PostgreSQL version 16.6.
- Configured a 3-instance PostgreSQL cluster with specific storage and resource settings.
- Enabled superuser access and set PostgreSQL parameters.
- Added backup configuration with S3 as the destination.
- Created a kustomization.yaml file to manage resources including cluster.yaml and scheduledbackup.yaml.
- Added a scheduledbackup.yaml file to schedule daily backups for the PostgreSQL cluster.
- Updated ks.yaml to include a new kustomization for the CloudNative PG cluster.
- Modified cluster-secrets.secret.sops.yaml to include a new encrypted Cloudflare account ID.