### PR TITLE
chore(cluster): remove hugepages limit from cluster configuration

### DIFF
--- a/openshift/main/apps/database/cloudnative-pg/cluster/cluster.yaml
+++ b/openshift/main/apps/database/cloudnative-pg/cluster/cluster.yaml
@@ -22,7 +22,6 @@ spec:
     requests:
       cpu: 500m
     limits:
-      hugepages-2Mi: 2Gi # Requires sysctl set on the host
       memory: 4Gi
   monitoring:
     enablePodMonitor: true


### PR DESCRIPTION
The hugepages-2Mi limit of 2Gi has been removed from the cluster.yaml file. This change eliminates the requirement for sysctl settings on the host related to hugepages.