### PR TITLE
feat(ansible): add route_host configuration to automation-platform.yaml

### DIFF
--- a/openshift/main/apps/ansible/ansible/app/automation-platform.yaml
+++ b/openshift/main/apps/ansible/ansible/app/automation-platform.yaml
@@ -7,6 +7,7 @@ spec:
   route_tls_termination_mechanism: Edge
   service_type: ClusterIP
   ingress_type: Route
+  route_host: demo.ansible.show
   no_log: true
   hostname: demo.ansible.show
   redis_mode: cluster


### PR DESCRIPTION
Added the `route_host` field with the value `demo.ansible.show` to the automation-platform.yaml file to specify the host for the route. This change enhances the configuration by explicitly defining the route host.