### PR TITLE
feat(automation-platform): add file storage access mode to hub configuration

### DIFF
--- a/openshift/main/apps/ansible/ansible/app/automation-platform.yaml
+++ b/openshift/main/apps/ansible/ansible/app/automation-platform.yaml
@@ -21,5 +21,6 @@ spec:
     postgres_configuration_secret: demo-eda-postgres-configuration
     db_fields_encryption_secret: demo-eda-postgres-configuration
   hub:
+    file_storage_access_mode: ReadWriteOnce
     postgres_configuration_secret: demo-hub-postgres-configuration
     secret_key_secret: demo-hub-postgres-configuration


### PR DESCRIPTION
Added `file_storage_access_mode: ReadWriteOnce` to the hub configuration in the automation-platform.yaml file to specify the access mode for file storage.