### PR TITLE
fix(security): set specific user and group IDs for pod security context

### DIFF
--- a/openshift/main/apps/volsync-system/volsync/app/helmrelease.yaml
+++ b/openshift/main/apps/volsync-system/volsync/app/helmrelease.yaml
@@ -32,6 +32,6 @@ spec:
       disableAuth: true
     podSecurityContext:
       runAsNonRoot: true
-      runAsUser: null
-      runAsGroup: null
+      runAsUser: 1000690001
+      runAsGroup: 1000690001
       seccompProfile: { type: RuntimeDefault }


### PR DESCRIPTION
Updated the `runAsUser` and `runAsGroup` fields in the pod security context to use specific IDs (1000690001) instead of null, enhancing security by ensuring the pod runs as a non-root user.