### PR TITLE
chore: update security context constraints

### DIFF
--- a/openshift/main/apps/volsync-system/namespace.yaml
+++ b/openshift/main/apps/volsync-system/namespace.yaml
@@ -6,6 +6,6 @@ metadata:
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
     openshift.io/sa.scc.mcs: s0:c26,c20
-    openshift.io/sa.scc.supplemental-groups: 1000690000/10000
-    openshift.io/sa.scc.uid-range: 1000690000/10000
+    openshift.io/sa.scc.supplemental-groups: 1002000000/10000
+    openshift.io/sa.scc.uid-range: 1002000000/10000
     volsync.backube/privileged-movers: "true"

--- a/openshift/main/apps/volsync-system/volsync/app/helmrelease.yaml
+++ b/openshift/main/apps/volsync-system/volsync/app/helmrelease.yaml
@@ -32,6 +32,6 @@ spec:
       disableAuth: true
     podSecurityContext:
       runAsNonRoot: true
-      runAsUser: 1000690001
-      runAsGroup: 1000690001
+      runAsUser: 1002000001
+      runAsGroup: 1002000001
       seccompProfile: { type: RuntimeDefault }


### PR DESCRIPTION
Updated the supplemental groups and UID range in the namespace.yaml to 1002000000/10000. Also modified the runAsUser and runAsGroup in helmrelease.yaml to 1002000001 to align with the new security context constraints. This is required because there is a default namespace from openshift that has overlapping UIDs.