### PR TITLE
chore(namespace): remove unnecessary MCS annotation

### DIFF
--- a/openshift/main/apps/volsync-system/namespace.yaml
+++ b/openshift/main/apps/volsync-system/namespace.yaml
@@ -5,7 +5,6 @@ metadata:
   name: volsync-system
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
-    openshift.io/sa.scc.mcs: s0:c26,c20
     openshift.io/sa.scc.supplemental-groups: 1002000000/10000
     openshift.io/sa.scc.uid-range: 1002000000/10000
     volsync.backube/privileged-movers: "true"


### PR DESCRIPTION
The MCS annotation 'openshift.io/sa.scc.mcs: s0:c26,c20' has been removed from the volsync-system namespace configuration as it is no longer required.