### PR TITLE
feat(ansible): add control_plane_ee_image to automation-platform.yaml

### DIFF
--- a/openshift/main/apps/ansible/ansible/app/automation-platform.yaml
+++ b/openshift/main/apps/ansible/ansible/app/automation-platform.yaml
@@ -18,6 +18,7 @@ spec:
   controller:
     postgres_configuration_secret: demo-controller-postgres-configuration
     secret_key_secret: demo-controller-postgres-configuration
+    control_plane_ee_image: demo.ansible.show/ee-supported-rhel9:latest
   eda:
     postgres_configuration_secret: demo-eda-postgres-configuration
     db_fields_encryption_secret: demo-eda-postgres-configuration


### PR DESCRIPTION
Added the `control_plane_ee_image` field to the controller section in the `automation-platform.yaml` file. This specifies the image `demo.ansible.show/ee-supported-rhel9:latest` for the control plane execution environment.