### PR TITLE
feat(ansible): add empty ee_images array to automation-platform.yaml

### DIFF
--- a/openshift/main/apps/ansible/ansible/app/automation-platform.yaml
+++ b/openshift/main/apps/ansible/ansible/app/automation-platform.yaml
@@ -19,6 +19,7 @@ spec:
     postgres_configuration_secret: demo-controller-postgres-configuration
     secret_key_secret: demo-controller-postgres-configuration
     control_plane_ee_image: demo.ansible.show/ee-supported-rhel9:latest
+    ee_images: []
   eda:
     postgres_configuration_secret: demo-eda-postgres-configuration
     db_fields_encryption_secret: demo-eda-postgres-configuration


### PR DESCRIPTION
Added an empty ee_images array to the automation-platform.yaml file under the spec section. This change should remove the default execution environments that are not used.