### PR TITLE
feat(volsync-system): enable snapshot-controller and volsync kustomizations

### DIFF
--- a/openshift/main/apps/volsync-system/kustomization.yaml
+++ b/openshift/main/apps/volsync-system/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
   # Pre Flux-Kustomizations
   - ./namespace.yaml
   # Flux-Kustomizations
-  # - ./snapshot-controller/ks.yaml
-  # - ./volsync/ks.yaml
+  - ./snapshot-controller/ks.yaml
+  - ./volsync/ks.yaml


### PR DESCRIPTION
Uncommented the snapshot-controller and volsync kustomizations in the kustomization.yaml file to include them in the build process. This change activates the previously disabled configurations for the volsync-system.