### PR TITLE
feat(namespace): add MCS annotation for volsync-system

### DIFF
--- a/openshift/main/apps/volsync-system/namespace.yaml
+++ b/openshift/main/apps/volsync-system/namespace.yaml
@@ -5,6 +5,7 @@ metadata:
   name: volsync-system
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    openshift.io/sa.scc.mcs: s0:c5000,c5001
     openshift.io/sa.scc.supplemental-groups: 1002000000/10000
     openshift.io/sa.scc.uid-range: 1002000000/10000
     volsync.backube/privileged-movers: "true"


### PR DESCRIPTION
Added the `openshift.io/sa.scc.mcs` annotation to the volsync-system namespace to specify the MCS label `s0:c5000,c5001`. This change enhances security context constraints for the service account.