### PR TITLE
feat(snapshot-controller): enhance security context

### DIFF
--- a/openshift/main/apps/volsync-system/snapshot-controller/app/helmrelease.yaml
+++ b/openshift/main/apps/volsync-system/snapshot-controller/app/helmrelease.yaml
@@ -29,3 +29,6 @@ spec:
       replicaCount: 2
       serviceMonitor:
         create: true
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1002000001


### PR DESCRIPTION
Added security context to run the snapshot-controller as a non-root user. Configured `runAsNonRoot` to true and set `runAsUser` to 1002000001 to improve security posture.