### PR TITLE
feat(dragonfly): add Dragonfly operator and cluster configuration

### DIFF
--- a/openshift/main/apps/database/dragonfly/app/helmrelease.yaml
+++ b/openshift/main/apps/database/dragonfly/app/helmrelease.yaml
@@ -1,0 +1,100 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2beta2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app dragonfly-operator
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 3.2.1
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    controllers:
+      dragonfly-operator:
+        replicas: 1
+        strategy: RollingUpdate
+        containers:
+          app:
+            image:
+              repository: ghcr.io/dragonflydb/operator
+              tag: v1.1.3@sha256:4c512cfc5498558f7a0a44cee69195e6c9b72f5d2cafeec9be487d95b3708978
+            command: ["/manager"]
+            args:
+              - --health-probe-bind-address=:8081
+              - --metrics-bind-address=:8080
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: &port 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /readyz
+                    port: *port
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 128Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+        pod:
+          securityContext:
+            runAsNonRoot: true
+          topologySpreadConstraints:
+            - maxSkew: 1
+              topologyKey: kubernetes.io/hostname
+              whenUnsatisfiable: DoNotSchedule
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: *app
+    service:
+      app:
+        controller: *app
+        ports:
+          http:
+            port: *port
+          metrics:
+            port: 8080
+    serviceMonitor:
+      app:
+        serviceName: *app
+        endpoints:
+          - port: metrics
+            scheme: http
+            path: /metrics
+            interval: 1m
+            scrapeTimeout: 10s
+    serviceAccount:
+      create: true
+      name: *app

--- a/openshift/main/apps/database/dragonfly/app/kustomization.yaml
+++ b/openshift/main/apps/database/dragonfly/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  # renovate: datasource=github-releases depName=dragonflydb/dragonfly-operator
+  - https://raw.githubusercontent.com/dragonflydb/dragonfly-operator/v1.1.7/manifests/crd.yaml
+  - ./helmrelease.yaml
+  - ./rbac.yaml

--- a/openshift/main/apps/database/dragonfly/app/rbac.yaml
+++ b/openshift/main/apps/database/dragonfly/app/rbac.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dragonfly-operator
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+  - apiGroups: [""]
+    resources: ["pods", "services"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["dragonflydb.io"]
+    resources: ["dragonflies"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["dragonflydb.io"]
+    resources: ["dragonflies/finalizers"]
+    verbs: ["update"]
+  - apiGroups: ["dragonflydb.io"]
+    resources: ["dragonflies/status"]
+    verbs: ["get", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dragonfly-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dragonfly-operator
+subjects:
+  - kind: ServiceAccount
+    name: dragonfly-operator
+    namespace: database

--- a/openshift/main/apps/database/dragonfly/cluster/cluster.yaml
+++ b/openshift/main/apps/database/dragonfly/cluster/cluster.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/dragonflydb.io/dragonfly_v1alpha1.json
+apiVersion: dragonflydb.io/v1alpha1
+kind: Dragonfly
+metadata:
+  name: dragonfly
+spec:
+  image: ghcr.io/dragonflydb/dragonfly:v1.23.1
+  replicas: 3 # set to the number of nodes in the cluster
+  skipFSGroup: true
+  env:
+    - name: MAX_MEMORY
+      valueFrom:
+        resourceFieldRef:
+          resource: limits.memory
+          divisor: 1Mi
+  args:
+    - --maxmemory=$(MAX_MEMORY)Mi
+    - --proactor_threads=2
+    - --cluster_mode=emulated
+  resources:
+    requests:
+      cpu: 100m
+    limits:
+      memory: 512Mi

--- a/openshift/main/apps/database/dragonfly/cluster/kustomization.yaml
+++ b/openshift/main/apps/database/dragonfly/cluster/kustomization.yaml
@@ -3,8 +3,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  # Pre Flux-Kustomizations
-  - ./namespace.yaml
-  # Flux-Kustomizations
-  - ./cloudnative-pg/ks.yaml
-  - ./dragonfly/ks.yaml
+  - ./cluster.yaml

--- a/openshift/main/apps/database/dragonfly/ks.yaml
+++ b/openshift/main/apps/database/dragonfly/ks.yaml
@@ -1,0 +1,46 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app dragonfly
+  namespace: flux-system
+spec:
+  targetNamespace: database
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: external-secrets-stores
+  path: ./openshift/main/apps/database/dragonfly/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: ocp-neptune
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app dragonfly-cluster
+  namespace: flux-system
+spec:
+  targetNamespace: database
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: dragonfly
+  path: ./openshift/main/apps/database/dragonfly/cluster
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: ocp-neptune
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
- Introduced HelmRelease for Dragonfly operator in `helmrelease.yaml` with necessary configurations for deployment and monitoring.
- Added `kustomization.yaml` for Dragonfly app to manage resources including CRD and RBAC.
- Created `rbac.yaml` to define ClusterRole and ClusterRoleBinding for Dragonfly operator permissions.
- Defined Dragonfly cluster configuration in `cluster.yaml` with image, replicas, and resource limits.
- Added `ks.yaml` for managing Dragonfly and Dragonfly-cluster kustomizations in the Flux system.
- Updated main database `kustomization.yaml` to include Dragonfly kustomization.