### PR TITLE
feat(netbox): disable internal Redis and configure external Redis services

### DIFF
--- a/openshift/main/apps/infra/netbox/app/helmrelease.yaml
+++ b/openshift/main/apps/infra/netbox/app/helmrelease.yaml
@@ -89,7 +89,13 @@ spec:
     postgresql:
       enabled: false
     redis:
-      enabled: true
+      enabled: false
+    tasksRedis:
+      host: dragonfly.database.svc.cluster.local
+      port: 6379
+    cachingRedis:
+      host: dragonfly.database.svc.cluster.local
+      port: 6379
     externalDatabase:
       host: postgres-rw.database.svc.cluster.local
       port: 5432


### PR DESCRIPTION
- Disabled the internal Redis service by setting `redis.enabled` to false.
- Configured external Redis services for tasks and caching by adding `tasksRedis` and `cachingRedis` with host `dragonfly.database.svc.cluster.local` and port `6379`.