### PR TITLE
fix: reduce compact cluster service footprint

### DIFF
--- a/openshift/apps/ansible/automation-platform/cluster/automation-platform.yaml
+++ b/openshift/apps/ansible/automation-platform/cluster/automation-platform.yaml
@@ -10,9 +10,13 @@ spec:
   route_host: demo.${SECRET_DOMAIN}
   no_log: true
   hostname: demo.${SECRET_DOMAIN}
-  redis_mode: cluster
+  redis_mode: standalone
+  redis:
+    replicas: 1
   db_fields_encryption_secret: automation-gateway-postgres-secret
   admin_password_secret: admin-password-secret
+  api:
+    replicas: 1
   database:
     database_secret: automation-gateway-postgres-secret
   controller:
@@ -24,13 +28,29 @@ spec:
     database:
       database_secret: eda-controller-postgres-secret
     db_fields_encryption_secret: eda-controller-postgres-secret
+    scheduler:
+      replicas: 1
+    default_worker:
+      replicas: 1
+    activation_worker:
+      replicas: 1
+    redis:
+      replicas: 1
+    event_stream:
+      replicas: 1
   hub:
     storage_type: S3
     object_storage_s3_secret: automation-hub-s3-secret
     postgres_configuration_secret: automation-hub-postgres-secret
     secret_key_secret: automation-hub-postgres-secret
+    api:
+      replicas: 1
+    content:
+      replicas: 1
+    web:
+      replicas: 1
     worker:
-      replicas: 2
+      replicas: 1
   lightspeed:
     disabled: false
     chatbot_config_secret_name: chatbot-configuration-secret

--- a/openshift/apps/database/dragonfly/cluster/cluster.yaml
+++ b/openshift/apps/database/dragonfly/cluster/cluster.yaml
@@ -6,7 +6,7 @@ metadata:
   name: dragonfly
 spec:
   image: ghcr.io/dragonflydb/dragonfly:v1.23.1
-  replicas: 3 # set to the number of nodes in the cluster
+  replicas: 1
   skipFSGroup: true
   env:
     - name: MAX_MEMORY
@@ -17,7 +17,6 @@ spec:
   args:
     - --maxmemory=$(MAX_MEMORY)Mi
     - --proactor_threads=2
-    - --cluster_mode=emulated
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
## Summary
- switch the AAP parent CR to standalone Redis and reduce AAP worker-oriented replicas to 1
- scale Dragonfly down to a single standalone instance instead of a 3-node emulated cluster
- reduce resource pressure on the compact OpenShift cluster while keeping the changes Flux-managed

## Validation
- oc kustomize openshift/apps/ansible/automation-platform/cluster | oc apply --dry-run=client -f -
- oc kustomize openshift/apps/database/dragonfly/cluster | oc apply --dry-run=client -f -